### PR TITLE
[RF004-FE-1] Tela de listagem de veículos

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -4,6 +4,7 @@ import { Switch } from 'react-router-dom';
 import BrandRegistry from '../screens/Brands/BrandRegistry';
 import BrandsList from '../screens/Brands/BrandsList';
 import Login from '../screens/Login';
+import VehiclesList from '../screens/Vehicles/VehiclesList';
 
 import AuthenticationRoute from './AuthenticationRoute';
 
@@ -27,8 +28,8 @@ const Routes = () => (
     <AuthenticationRoute exact path="/login">
       <Login />
     </AuthenticationRoute>
-    <AuthenticationRoute path="/">
-      <div>veículos</div>
+    <AuthenticationRoute exact path="/">
+      <VehiclesList />
     </AuthenticationRoute>
   </Switch>
 );

--- a/src/screens/Vehicles/VehiclesList/columns.js
+++ b/src/screens/Vehicles/VehiclesList/columns.js
@@ -1,0 +1,29 @@
+const columns = [
+  {
+    field: 'brand',
+    headerName: 'Marca',
+    flex: 1,
+  },
+  {
+    field: 'model',
+    headerName: 'Modelo',
+    flex: 1,
+    sortable: false,
+  },
+  {
+    field: 'year',
+    headerName: 'Ano',
+    type: 'number',
+    flex: 1,
+    valueFormatter: ({ value }) => (value ? `${value}` : ''),
+  },
+  {
+    field: 'value',
+    headerName: 'Valor',
+    type: 'number',
+    flex: 1,
+    valueFormatter: ({ value }) => (value ? `R$ ${value}` : ''),
+  },
+];
+
+export default columns;

--- a/src/screens/Vehicles/VehiclesList/index.js
+++ b/src/screens/Vehicles/VehiclesList/index.js
@@ -1,14 +1,23 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo, useContext } from 'react';
+import { Link } from 'react-router-dom';
 
 import { DataGrid } from '@material-ui/data-grid';
+import { Button } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
 
 import columns from './columns';
 import VehicleService from '../services';
 import vehicleParser from './vehicleParser';
+import Authentication from '../../../contexts/authentication';
 
 const VehiclesList = () => {
+  const { isLoggedIn } = useContext(Authentication);
   const [vehicles, setVehicles] = useState([]);
+  const [selectedVehicle, setSelectedVehicle] = useState({});
   const [isLoading, setIsLoading] = useState(false);
+  const shouldDisableButtons = useMemo(() =>
+    selectedVehicle && Object.keys(selectedVehicle).length === 0,
+  [selectedVehicle]);
 
   const loadVehicles = () => {
     VehicleService.getAll()
@@ -20,21 +29,54 @@ const VehiclesList = () => {
       });
   };
 
+  const deleteVehicle = () => {
+    VehicleService.delete(selectedVehicle);
+  };
+
   useEffect(() => {
     setIsLoading(true);
     loadVehicles();
   }, []);
 
   return (
-    <DataGrid
-      autoHeight
-      columns={columns}
-      rows={vehicles}
-      disableColumnMenu
-      disableColumnSelector
-      disableDensitySelector
-      loading={isLoading}
-    />
+    <>
+      <DataGrid
+        columns={columns}
+        rows={vehicles}
+        loading={isLoading}
+        onRowSelected={(gridSelection) => setSelectedVehicle(gridSelection.data)}
+        autoHeight
+        disableColumnMenu
+        disableColumnSelector
+        disableDensitySelector
+      />
+      {isLoggedIn &&
+        <Box display="flex" justifyContent="flex-end" mt={2}>
+          <Button
+            variant="contained"
+            color="secondary"
+            onClick={deleteVehicle}
+            disabled={shouldDisableButtons}
+          >
+            Excluir
+          </Button>
+          <Box mx={1}>
+            <Button
+              to={`alteracao-veiculo/${selectedVehicle.id}`}
+              component={Link}
+              variant="contained"
+              color="primary"
+              disabled={shouldDisableButtons}
+            >
+              Alterar
+            </Button>
+          </Box>
+          <Button to="/cadastro-veiculo" component={Link} variant="contained" color="primary">
+            Incluir
+          </Button>
+        </Box>
+      }
+    </>
   );
 };
 

--- a/src/screens/Vehicles/VehiclesList/index.js
+++ b/src/screens/Vehicles/VehiclesList/index.js
@@ -19,6 +19,7 @@ const VehiclesList = () => {
   const shouldDisableButtons = useMemo(() =>
     selectedVehicle && Object.keys(selectedVehicle).length === 0,
   [selectedVehicle]);
+  const handleOnRowSelected = (selectedRow) => setSelectedVehicle(selectedRow.data);
 
   const loadVehicles = () => {
     VehicleService.getAll()
@@ -50,7 +51,7 @@ const VehiclesList = () => {
         columns={columns}
         rows={vehicles}
         loading={isLoading}
-        onRowSelected={(gridSelection) => setSelectedVehicle(gridSelection.data)}
+        onRowSelected={handleOnRowSelected}
         autoHeight
         disableColumnMenu
         disableColumnSelector

--- a/src/screens/Vehicles/VehiclesList/index.js
+++ b/src/screens/Vehicles/VehiclesList/index.js
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+
+import { DataGrid } from '@material-ui/data-grid';
+
+import columns from './columns';
+import VehicleService from '../services';
+import vehicleParser from './vehicleParser';
+
+const VehiclesList = () => {
+  const [vehicles, setVehicles] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadVehicles = () => {
+    VehicleService.getAll()
+      .then((data) => {
+        setVehicles(vehicleParser(data));
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    setIsLoading(true);
+    loadVehicles();
+  }, []);
+
+  return (
+    <DataGrid
+      autoHeight
+      columns={columns}
+      rows={vehicles}
+      disableColumnMenu
+      disableColumnSelector
+      disableDensitySelector
+      loading={isLoading}
+    />
+  );
+};
+
+export default VehiclesList;

--- a/src/screens/Vehicles/VehiclesList/index.js
+++ b/src/screens/Vehicles/VehiclesList/index.js
@@ -2,8 +2,9 @@ import React, { useEffect, useState, useMemo, useContext } from 'react';
 import { Link } from 'react-router-dom';
 
 import { DataGrid } from '@material-ui/data-grid';
-import { Button } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
 import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
 
 import columns from './columns';
 import VehicleService from '../services';
@@ -40,6 +41,11 @@ const VehiclesList = () => {
 
   return (
     <>
+      <Box mb={4}>
+        <Typography variant="h3" component="h2">
+          Lista de veículos
+        </Typography>
+      </Box>
       <DataGrid
         columns={columns}
         rows={vehicles}

--- a/src/screens/Vehicles/VehiclesList/tests/columns.test.js
+++ b/src/screens/Vehicles/VehiclesList/tests/columns.test.js
@@ -1,0 +1,35 @@
+import columns from '../columns';
+
+const findColumnByFieldName = (field) => columns.find((column) => column.field === field);
+
+describe('Vehicle lists columns value formatters', () => {
+  describe('Value formatter', () => {
+    it('should format the vehicle value correctly', () => {
+      const vehicleValueFormatter = findColumnByFieldName('value').valueFormatter;
+      const mockedValue = 8000;
+      const expectedReturn = 'R$ 8000';
+      expect(vehicleValueFormatter({ value: mockedValue })).toBe(expectedReturn);
+    });
+
+    it('should return an empty string if the value is empty', () => {
+      const vehicleValueFormatter = findColumnByFieldName('value').valueFormatter;
+      const expectedReturn = '';
+      expect(vehicleValueFormatter({})).toBe(expectedReturn);
+    });
+  });
+
+  describe('Year formatter', () => {
+    it('should format the vehicle year correctly', () => {
+      const vehicleYearFormatter = findColumnByFieldName('year').valueFormatter;
+      const mockedYear = 1998;
+      const expectedReturn = '1998';
+      expect(vehicleYearFormatter({ value: mockedYear })).toBe(expectedReturn);
+    });
+
+    it('should return an empty string if the year is empty', () => {
+      const vehicleYearFormatter = findColumnByFieldName('year').valueFormatter;
+      const expectedReturn = '';
+      expect(vehicleYearFormatter({})).toBe(expectedReturn);
+    });
+  });
+});

--- a/src/screens/Vehicles/VehiclesList/tests/index.test.js
+++ b/src/screens/Vehicles/VehiclesList/tests/index.test.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+
+import VehiclesList from '..';
+import VehicleService from '../../services';
+import mockedVehicles from './mockedVehicles';
+
+jest.mock('../../services');
+
+describe('<VehiclesList />', () => {
+  it('should render the vehicles list correctly', async () => {
+    VehicleService.getAll.mockImplementationOnce(() => Promise.resolve(mockedVehicles));
+    render(<VehiclesList />);
+
+    await waitFor(() => expect(screen.getAllByRole('row')).toHaveLength(6));
+  });
+});

--- a/src/screens/Vehicles/VehiclesList/tests/index.test.js
+++ b/src/screens/Vehicles/VehiclesList/tests/index.test.js
@@ -1,17 +1,113 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 import VehiclesList from '..';
 import VehicleService from '../../services';
 import mockedVehicles from './mockedVehicles';
+import Authentication from '../../../../contexts/authentication';
 
 jest.mock('../../services');
 
 describe('<VehiclesList />', () => {
-  it('should render the vehicles list correctly', async () => {
-    VehicleService.getAll.mockImplementationOnce(() => Promise.resolve(mockedVehicles));
-    render(<VehiclesList />);
+  describe('rendering', () => {
+    it('should render the VehiclesList component correctly', async () => {
+      const mockedState = {
+        isLoggedIn: true,
+      };
+      VehicleService.getAll.mockImplementationOnce(() => Promise.resolve(mockedVehicles));
+      render(
+        <Authentication.Provider value={mockedState}>
+          <MemoryRouter>
+            <VehiclesList />
+          </MemoryRouter>
+        </Authentication.Provider>,
+      );
+      await waitFor(() =>
+        expect(screen.getAllByRole('row')).toHaveLength(6),
+        expect(screen.getByRole('button', { name: 'Excluir' })).toBeInTheDocument(),
+        expect(screen.getByRole('button', { name: 'Alterar' })).toBeInTheDocument(),
+        expect(screen.getByRole('button', { name: 'Incluir' })).toBeInTheDocument(),
+      );
+    });
 
-    await waitFor(() => expect(screen.getAllByRole('row')).toHaveLength(6));
+    it('should not render the buttons if the user is not logged in', async () => {
+      const mockedState = {
+        isLoggedIn: false,
+      };
+      VehicleService.getAll.mockImplementationOnce(() => Promise.resolve(mockedVehicles));
+      render(
+        <Authentication.Provider value={mockedState}>
+          <MemoryRouter>
+            <VehiclesList />
+          </MemoryRouter>
+        </Authentication.Provider>,
+      );
+
+      await waitFor(
+        () => expect(screen.queryAllByText('Excluir')).toHaveLength(0),
+        expect(screen.queryAllByText('Alterar')).toHaveLength(0),
+        expect(screen.queryAllByText('Incluir')).toHaveLength(0),
+      );
+    });
+  });
+
+  describe('button enabling', () => {
+    it('should enable the buttons after a row is clicked', async () => {
+      const mockedState = {
+        isLoggedIn: true,
+      };
+      VehicleService.getAll.mockImplementationOnce(() => Promise.resolve(mockedVehicles));
+      render(
+        <Authentication.Provider value={mockedState}>
+          <MemoryRouter>
+            <VehiclesList />
+          </MemoryRouter>
+        </Authentication.Provider>,
+      );
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Excluir' })).toBeDisabled(),
+        expect(
+          screen.getByRole('button', { name: 'Alterar' }).attributes.getNamedItem('aria-disabled'),
+        ).toBeTruthy(),
+      );
+
+      const firstVehicleRow = screen.getAllByRole('row')[1];
+      fireEvent.click(firstVehicleRow);
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Excluir' })).toBeEnabled(),
+        expect(
+          screen.getByRole('button', { name: 'Alterar' })
+        ).toHaveAttribute('aria-disabled', 'false'),
+      );
+    });
+  });
+
+  describe('button functioning', () => {
+    it('should enable the buttons after a row is clicked', async () => {
+      const mockedState = {
+        isLoggedIn: true,
+      };
+      VehicleService.getAll.mockImplementationOnce(() => Promise.resolve(mockedVehicles));
+      VehicleService.delete.mockImplementation(() => {});
+      render(
+        <Authentication.Provider value={mockedState}>
+          <MemoryRouter>
+            <VehiclesList />
+          </MemoryRouter>
+        </Authentication.Provider>,
+      );
+
+      await waitFor(() => expect(screen.getAllByRole('row')).toHaveLength(6));
+
+      const firstVehicleRow = screen.getAllByRole('row')[1];
+      const deleteButton = screen.getByRole('button', { name: 'Excluir' });
+      fireEvent.click(firstVehicleRow);
+      fireEvent.click(deleteButton);
+
+      await waitFor(() => expect(VehicleService.delete).toHaveBeenCalled());
+    });
   });
 });

--- a/src/screens/Vehicles/VehiclesList/tests/index.test.js
+++ b/src/screens/Vehicles/VehiclesList/tests/index.test.js
@@ -28,6 +28,7 @@ describe('<VehiclesList />', () => {
         expect(screen.getByRole('button', { name: 'Excluir' })).toBeInTheDocument(),
         expect(screen.getByRole('button', { name: 'Alterar' })).toBeInTheDocument(),
         expect(screen.getByRole('button', { name: 'Incluir' })).toBeInTheDocument(),
+        expect(screen.getByText('Lista de veículos')).toBeInTheDocument(),
       );
     });
 

--- a/src/screens/Vehicles/VehiclesList/tests/mockedVehicles.js
+++ b/src/screens/Vehicles/VehiclesList/tests/mockedVehicles.js
@@ -1,0 +1,9 @@
+const mockedVehicles = [
+  { id: 4, marca: { nome: 'FIAT' }, modelo: 'Gol Bolinha', ano: 2000, valor: 5000 },
+  { id: 5, marca: { nome: 'FIAT' }, modelo: 'Uno', ano: 1998, valor: 7900 },
+  { id: 1, marca: { nome: 'FORD' }, modelo: 'KA', ano: 2020, valor: 10800 },
+  { id: 2, marca: { nome: 'GM' }, modelo: 'Corsa', ano: 2015, valor: 15000 },
+  { id: 3, marca: { nome: 'FORD' }, modelo: 'Palio', ano: 2003, valor: 9000 },
+];
+
+export default mockedVehicles;

--- a/src/screens/Vehicles/VehiclesList/tests/vehicleParser.test.js
+++ b/src/screens/Vehicles/VehiclesList/tests/vehicleParser.test.js
@@ -1,0 +1,28 @@
+import vehicleParser from '../vehicleParser';
+
+const mockedVehiclesServiceGetAllReturn = [
+  { id: 134, modelo: 'KA 123456', ano: 2021, valor: 80000.0, marca: { id: 34, nome: 'FORD' } },
+  { id: 154, modelo: 'teste', ano: 2000, valor: 10000.0, marca: { id: 34, nome: 'FIAT' } },
+];
+
+describe('vehicleParser', () => {
+  it('should parse the vehicles get all service return correctly', () => {
+    const expectedReturn = [
+      {
+        id: 134,
+        model: 'KA 123456',
+        year: 2021,
+        value: 80000,
+        brand: 'FORD',
+      },
+      {
+        id: 154,
+        model: 'teste',
+        year: 2000,
+        value: 10000,
+        brand: 'FIAT',
+      },
+    ];
+    expect(vehicleParser(mockedVehiclesServiceGetAllReturn)).toEqual(expectedReturn);
+  });
+});

--- a/src/screens/Vehicles/VehiclesList/vehicleParser.js
+++ b/src/screens/Vehicles/VehiclesList/vehicleParser.js
@@ -1,0 +1,10 @@
+const vehicleParser = (vehicles) =>
+  vehicles.map((vehicle) => ({
+    id: vehicle.id,
+    brand: vehicle.marca.nome,
+    year: vehicle.ano,
+    value: vehicle.valor,
+    model: vehicle.modelo,
+  }));
+
+export default vehicleParser;

--- a/src/screens/Vehicles/services/index.js
+++ b/src/screens/Vehicles/services/index.js
@@ -2,6 +2,9 @@ const VehicleService = {
   async getAll() {
     return fetch('https://carango-bom-api.herokuapp.com/veiculos').then((r) => r.json());
   },
+  delete() {
+    return true;
+  }
 };
 
 export default VehicleService;


### PR DESCRIPTION
## Descrição

Esse PR adiciona a tela de listagem de veículos na aplicação, a tela pode ser acessada através da rota da padrão (`/`). A tela possui as seguintes funcionalidades:
- Consome dados dos veículos de uma API "fake" (não desenvolvida para essa aplicação);
- Botões da página apenas são renderizados se o usuários estiver logado;
- Botões de alterar e excluir só são habilitados caso algum veículo da lista esteja selecionado;
- Botões redirecionam para as rotas corretas, e o botão de excluir chama a função de excluir veículo que será desenvolvida durante a tarefa de conectar essa página com o backend do projeto;
- Dados consumidos pelo endpoint de veículos são parseados para um modelo que o componente de `DataGrid` do material-ui compreende de acordo com as colunas criadas;
- Todos os testes unitários correspondentes com essa página foram criados;
- **EXTRA**: esse PR também adiciona a prop `exact` nas rotas da aplicação para evitar que os usuários sejam redirecionados para alguma rota por acidente.

### Anexo
Imagem da tela desenvolvida:
![print screen da página de listagem de veículos](https://user-images.githubusercontent.com/17559048/123647303-5acd4880-d7fe-11eb-9989-43500f1f6f03.png)
