### PR TITLE
[RF004-FE-2] Conexão tela de listagem de veículos com backend

### DIFF
--- a/src/contexts/authentication.js
+++ b/src/contexts/authentication.js
@@ -10,6 +10,7 @@ const AuthenticationProvider = ({ children }) => {
     () => ({
       isLoggedIn: authState.isLoggedIn,
       isLoading: authState.isLoading,
+      userJWT: authState.userJWT,
       login: authState.login,
       logout: authState.logout,
     }),

--- a/src/screens/Vehicles/VehiclesList/hooks/tests/useVehicles.test.js
+++ b/src/screens/Vehicles/VehiclesList/hooks/tests/useVehicles.test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import useVehicles from '../useVehicles';
+import { getAllVehicles } from '../../../services';
+import { SnackBarContext } from '../../../../../contexts/snackbar';
+import mockedVehicles from '../../tests/mockedVehicles';
+import vehicleParser from '../../vehicleParser';
+
+jest.mock('../../../services');
+
+describe('useVehicles', () => {
+  const mockedValue = {
+    addAlert: jest.fn(),
+  };
+  const wrapper = ({ children }) => (
+    <SnackBarContext.Provider value={mockedValue}>
+      {children}
+    </SnackBarContext.Provider>
+  );
+
+  it('should handle the getAllVehicles correctly after the hook first useEffect', async () => {
+    getAllVehicles.mockImplementationOnce(() => Promise.resolve(mockedVehicles));
+
+    const { result, waitForNextUpdate } = renderHook(() => useVehicles(), { wrapper });
+    await waitForNextUpdate();
+    expect(result.current.vehicles).toEqual(vehicleParser(mockedVehicles));
+  });
+  
+  it('should update isLoading to true at the start of the getAllVehicles and to false after that',
+    async () => {
+      getAllVehicles.mockImplementationOnce(() => Promise.resolve(mockedVehicles));
+
+      const { result, waitForNextUpdate } = renderHook(() => useVehicles(), { wrapper });
+      expect(result.current.isLoading).toBeTruthy();
+      await waitForNextUpdate();
+      expect(result.current.isLoading).toBeFalsy();
+    }
+  );
+
+  it('should call the addAlert function when the getAllVehicles returns an error', async () => {
+    const mockedServiceReturn = { error: 'error' };
+    getAllVehicles.mockImplementationOnce(() => Promise.reject(mockedServiceReturn));
+
+    const { waitForNextUpdate } = renderHook(() => useVehicles(), { wrapper });
+    await waitForNextUpdate();
+    expect(mockedValue.addAlert).toHaveBeenCalledWith({
+      content: 'Erro inesperado ao carregar veículos!',
+      customSeverity: 'error',
+    });
+  });
+});

--- a/src/screens/Vehicles/VehiclesList/hooks/tests/useVehicles.test.js
+++ b/src/screens/Vehicles/VehiclesList/hooks/tests/useVehicles.test.js
@@ -1,51 +1,85 @@
 import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import useVehicles from '../useVehicles';
-import { getAllVehicles } from '../../../services';
+import { getAllVehicles, removeVehicle } from '../../../services';
 import { SnackBarContext } from '../../../../../contexts/snackbar';
+import { AuthenticationContext } from '../../../../../contexts/authentication';
 import mockedVehicles from '../../tests/mockedVehicles';
 import vehicleParser from '../../vehicleParser';
 
 jest.mock('../../../services');
 
 describe('useVehicles', () => {
-  const mockedValue = {
-    addAlert: jest.fn(),
-  };
+  const mockedSnackbarValue = { addAlert: jest.fn() };
+  const mockedAuthValue = { userJWT: 'fakeuserjwt' };
   const wrapper = ({ children }) => (
-    <SnackBarContext.Provider value={mockedValue}>
-      {children}
+    <SnackBarContext.Provider value={mockedSnackbarValue}>
+      <AuthenticationContext.Provider value={mockedAuthValue}>
+        {children}
+      </AuthenticationContext.Provider>
     </SnackBarContext.Provider>
   );
 
-  it('should handle the getAllVehicles correctly after the hook first useEffect', async () => {
-    getAllVehicles.mockImplementationOnce(() => Promise.resolve(mockedVehicles));
-
-    const { result, waitForNextUpdate } = renderHook(() => useVehicles(), { wrapper });
-    await waitForNextUpdate();
-    expect(result.current.vehicles).toEqual(vehicleParser(mockedVehicles));
-  });
-  
-  it('should update isLoading to true at the start of the getAllVehicles and to false after that',
-    async () => {
+  describe('getAllVehicles handling', () => {
+    it('should handle the getAllVehicles correctly after the hook first useEffect', async () => {
       getAllVehicles.mockImplementationOnce(() => Promise.resolve(mockedVehicles));
+  
+      const { result, waitForNextUpdate } = renderHook(() => useVehicles(), { wrapper });
+      await waitForNextUpdate();
+      expect(result.current.vehicles).toEqual(vehicleParser(mockedVehicles));
+    });
+    
+    it('should update isLoading to true at the start of the getAllVehicles and to false after that',
+      async () => {
+        getAllVehicles.mockImplementationOnce(() => Promise.resolve(mockedVehicles));
+  
+        const { result, waitForNextUpdate } = renderHook(() => useVehicles(), { wrapper });
+        expect(result.current.isLoading).toBeTruthy();
+        await waitForNextUpdate();
+        expect(result.current.isLoading).toBeFalsy();
+      }
+    );
+  
+    it('should call the addAlert function when the getAllVehicles returns an error', async () => {
+      const mockedServiceReturn = { error: 'error' };
+      getAllVehicles.mockImplementationOnce(() => Promise.reject(mockedServiceReturn));
+  
+      const { waitForNextUpdate } = renderHook(() => useVehicles(), { wrapper });
+      await waitForNextUpdate();
+      expect(mockedSnackbarValue.addAlert).toHaveBeenCalledWith({
+        content: 'Erro inesperado ao carregar veículos!',
+        customSeverity: 'error',
+      });
+    });
+  });
+
+  describe('removeVehicle handling', () => {
+    it('should remove one remove of the state correctly', async () => {
+      const mockedVehicleRemoved = { id: 3 };
+      getAllVehicles.mockImplementationOnce(() => Promise.resolve(mockedVehicles));
+      removeVehicle.mockImplementationOnce(() => Promise.resolve(mockedVehicleRemoved));
 
       const { result, waitForNextUpdate } = renderHook(() => useVehicles(), { wrapper });
-      expect(result.current.isLoading).toBeTruthy();
       await waitForNextUpdate();
-      expect(result.current.isLoading).toBeFalsy();
-    }
-  );
+      result.current.deleteVehicle(mockedVehicleRemoved.id)();
+      await waitForNextUpdate();
+      const removedVehicle = result.current.vehicles.find((vehicle) => vehicle.id === 3);
+      expect(removedVehicle).toBeUndefined();
+    });
 
-  it('should call the addAlert function when the getAllVehicles returns an error', async () => {
-    const mockedServiceReturn = { error: 'error' };
-    getAllVehicles.mockImplementationOnce(() => Promise.reject(mockedServiceReturn));
+    it('should call the addAlert function when the getAllVehicles returns an error', async () => {
+      const mockedServiceReturn = { error: 'error' };
+      getAllVehicles.mockImplementationOnce(() => Promise.resolve(mockedVehicles));
+      removeVehicle.mockImplementationOnce(() => Promise.reject(mockedServiceReturn));
 
-    const { waitForNextUpdate } = renderHook(() => useVehicles(), { wrapper });
-    await waitForNextUpdate();
-    expect(mockedValue.addAlert).toHaveBeenCalledWith({
-      content: 'Erro inesperado ao carregar veículos!',
-      customSeverity: 'error',
+      const { result, waitForNextUpdate, waitFor } = renderHook(() => useVehicles(), { wrapper });
+      await waitForNextUpdate();
+      result.current.deleteVehicle(2)();
+      await waitFor(() => expect(mockedSnackbarValue.addAlert).toHaveBeenCalled());
+      expect(mockedSnackbarValue.addAlert).toHaveBeenCalledWith({
+        content: 'Erro inesperado ao excluir veículo!',
+        customSeverity: 'error',
+      });
     });
   });
 });

--- a/src/screens/Vehicles/VehiclesList/hooks/useVehicles.js
+++ b/src/screens/Vehicles/VehiclesList/hooks/useVehicles.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useContext } from 'react';
 
 import { SnackBarContext } from '../../../../contexts/snackbar';
+import { AuthenticationContext } from '../../../../contexts/authentication';
 
 import { getAllVehicles, removeVehicle } from '../../services';
 import vehicleParser from '../vehicleParser';
@@ -9,6 +10,7 @@ const useVehicles = () => {
   const [vehicles, setVehicles] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const { addAlert } = useContext(SnackBarContext);
+  const { userJWT } = useContext(AuthenticationContext);
 
   const loadVehicles = () => {
     getAllVehicles()
@@ -23,8 +25,17 @@ const useVehicles = () => {
       });
   };
 
-  const deleteVehicle = (vehicleId) => {
-    removeVehicle(vehicleId);
+  const deleteVehicle = (vehicleId) => () => {
+    removeVehicle(vehicleId, userJWT)
+      .then((removedVehicle) => {
+        const vehiclesWithoutRemovedVehicle = vehicles.filter((vehicle) =>
+          vehicle.id !== removedVehicle.id
+        );
+        setVehicles(vehiclesWithoutRemovedVehicle);
+      })
+      .catch(() => {
+        addAlert({ content: 'Erro inesperado ao excluir veículo!', customSeverity: 'error' });
+      });
   };
 
   useEffect(() => {

--- a/src/screens/Vehicles/VehiclesList/hooks/useVehicles.js
+++ b/src/screens/Vehicles/VehiclesList/hooks/useVehicles.js
@@ -1,0 +1,38 @@
+import { useState, useEffect, useContext } from 'react';
+
+import { SnackBarContext } from '../../../../contexts/snackbar';
+
+import { getAllVehicles, removeVehicle } from '../../services';
+import vehicleParser from '../vehicleParser';
+
+const useVehicles = () => {
+  const [vehicles, setVehicles] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const { addAlert } = useContext(SnackBarContext);
+
+  const loadVehicles = () => {
+    getAllVehicles()
+      .then((data) => {
+        setVehicles(vehicleParser(data));
+      })
+      .catch(() => {
+        addAlert({ content: 'Erro inesperado ao carregar veículos!', customSeverity: 'error' });
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  const deleteVehicle = (vehicleId) => {
+    removeVehicle(vehicleId);
+  };
+
+  useEffect(() => {
+    setIsLoading(true);
+    loadVehicles();
+  }, []);
+
+  return {vehicles, isLoading, deleteVehicle};
+}
+
+export default useVehicles;

--- a/src/screens/Vehicles/VehiclesList/index.js
+++ b/src/screens/Vehicles/VehiclesList/index.js
@@ -41,7 +41,7 @@ const VehiclesList = () => {
           <Button
             variant="contained"
             color="secondary"
-            onClick={deleteVehicle}
+            onClick={deleteVehicle(selectedVehicle.id)}
             disabled={shouldDisableButtons}
           >
             Excluir

--- a/src/screens/Vehicles/VehiclesList/index.js
+++ b/src/screens/Vehicles/VehiclesList/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo, useContext } from 'react';
+import React, { useState, useMemo, useContext } from 'react';
 import { Link } from 'react-router-dom';
 
 import { DataGrid } from '@material-ui/data-grid';
@@ -6,39 +6,18 @@ import Button from '@material-ui/core/Button';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
 
-import columns from './columns';
-import VehicleService from '../services';
-import vehicleParser from './vehicleParser';
 import { AuthenticationContext } from '../../../contexts/authentication';
+import useVehicles from './hooks/useVehicles';
+import columns from './columns';
 
 const VehiclesList = () => {
   const { isLoggedIn } = useContext(AuthenticationContext);
-  const [vehicles, setVehicles] = useState([]);
+  const { vehicles, isLoading, deleteVehicle } = useVehicles();
   const [selectedVehicle, setSelectedVehicle] = useState({});
-  const [isLoading, setIsLoading] = useState(false);
   const shouldDisableButtons = useMemo(() =>
     selectedVehicle && Object.keys(selectedVehicle).length === 0,
   [selectedVehicle]);
   const handleOnRowSelected = (selectedRow) => setSelectedVehicle(selectedRow.data);
-
-  const loadVehicles = () => {
-    VehicleService.getAll()
-      .then((data) => {
-        setVehicles(vehicleParser(data));
-      })
-      .finally(() => {
-        setIsLoading(false);
-      });
-  };
-
-  const deleteVehicle = () => {
-    VehicleService.delete(selectedVehicle);
-  };
-
-  useEffect(() => {
-    setIsLoading(true);
-    loadVehicles();
-  }, []);
 
   return (
     <>

--- a/src/screens/Vehicles/VehiclesList/tests/vehicleParser.test.js
+++ b/src/screens/Vehicles/VehiclesList/tests/vehicleParser.test.js
@@ -1,8 +1,8 @@
 import vehicleParser from '../vehicleParser';
 
 const mockedVehiclesServiceGetAllReturn = [
-  { id: 134, modelo: 'KA 123456', ano: 2021, valor: 80000.0, marca: { id: 34, nome: 'FORD' } },
-  { id: 154, modelo: 'teste', ano: 2000, valor: 10000.0, marca: { id: 34, nome: 'FIAT' } },
+  { id: 134, modelo: 'KA 123456', ano: 2021, preco: 80000.0, marca: { id: 34, nome: 'FORD' } },
+  { id: 154, modelo: 'teste', ano: 2000, preco: 10000.0, marca: { id: 34, nome: 'FIAT' } },
 ];
 
 describe('vehicleParser', () => {

--- a/src/screens/Vehicles/VehiclesList/vehicleParser.js
+++ b/src/screens/Vehicles/VehiclesList/vehicleParser.js
@@ -3,7 +3,7 @@ const vehicleParser = (vehicles) =>
     id: vehicle.id,
     brand: vehicle.marca.nome,
     year: vehicle.ano,
-    value: vehicle.valor,
+    value: vehicle.preco,
     model: vehicle.modelo,
   }));
 

--- a/src/screens/Vehicles/services/index.js
+++ b/src/screens/Vehicles/services/index.js
@@ -1,10 +1,7 @@
-const VehicleService = {
-  async getAll() {
-    return fetch('https://carango-bom-api.herokuapp.com/veiculos').then((r) => r.json());
-  },
-  delete() {
-    return true;
-  }
-};
+import { API_URL } from "../../../services/constants";
+import fetchResponseHandler from "../../../services/fetchResponseHandler";
 
-export default VehicleService;
+export const getAllVehicles = async () =>
+  fetch(`${API_URL}/veiculo`).then(fetchResponseHandler);
+
+export const removeVehicle = () => true;

--- a/src/screens/Vehicles/services/index.js
+++ b/src/screens/Vehicles/services/index.js
@@ -1,7 +1,14 @@
 import { API_URL } from "../../../services/constants";
 import fetchResponseHandler from "../../../services/fetchResponseHandler";
+import buildAuthHeader from '../../../services/buildAuthHeader'
 
-export const getAllVehicles = async () =>
-  fetch(`${API_URL}/veiculo`).then(fetchResponseHandler);
+export const getAllVehicles = async () => fetch(`${API_URL}/veiculo`).then(fetchResponseHandler);
 
-export const removeVehicle = () => true;
+export const removeVehicle = async (vehicleId, userJWT) => {
+  const requestOptions = {
+    method: 'DELETE',
+    headers: buildAuthHeader(userJWT),
+  };
+
+  return fetch(`${API_URL}/veiculo/${vehicleId}`, requestOptions).then(fetchResponseHandler);
+};

--- a/src/screens/Vehicles/services/tests/index.test.js
+++ b/src/screens/Vehicles/services/tests/index.test.js
@@ -1,6 +1,7 @@
-import { getAllVehicles } from '..';
+import { getAllVehicles, removeVehicle } from '..';
 
 import { API_URL } from '../../../../services/constants';
+import buildAuthHeader from '../../../../services/buildAuthHeader';
 
 beforeAll(() => jest.spyOn(window, 'fetch'));
 
@@ -11,9 +12,27 @@ describe('Vehicles services', () => {
       json: async () => ({ success: true }),
     });
   });
-  it('should call the fetch function with the correct url', async () => {
-    getAllVehicles();
+  describe('getAllVehicles', () => {
+    it('should call the fetch function with the correct url', () => {
+      getAllVehicles();
+  
+      expect(window.fetch).toHaveBeenCalledWith(`${API_URL}/veiculo`);
+    });
+  });
 
-    expect(window.fetch).toHaveBeenCalledWith(`${API_URL}/veiculo`);
+  describe('removeVehicle', () => {
+    it('should call the fetch function with the correct url', () => {
+      const mockedVehicleId = 123;
+      const mockedJWT = 'fakeuserjwt';
+      removeVehicle(mockedVehicleId, mockedJWT);
+  
+      expect(window.fetch).toHaveBeenCalledWith(
+        `${API_URL}/veiculo/${mockedVehicleId}`,
+        {
+          method: 'DELETE',
+          headers: buildAuthHeader(mockedJWT),
+        },
+      );
+    });
   });
 });

--- a/src/screens/Vehicles/services/tests/index.test.js
+++ b/src/screens/Vehicles/services/tests/index.test.js
@@ -1,0 +1,19 @@
+import { getAllVehicles } from '..';
+
+import { API_URL } from '../../../../services/constants';
+
+beforeAll(() => jest.spyOn(window, 'fetch'));
+
+describe('Vehicles services', () => {
+  beforeEach(() => {
+    window.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+  });
+  it('should call the fetch function with the correct url', async () => {
+    getAllVehicles();
+
+    expect(window.fetch).toHaveBeenCalledWith(`${API_URL}/veiculo`);
+  });
+});


### PR DESCRIPTION
## Descrição
Esse PR cria funcionalidades necessárias para que a tela de listagem de veículos consuma e envie informações para o backend da aplicação corretamente. Para isso foi necessário:
- Criar serviços para consumir informações dos veículos (`getAllVehicles`) e para deletar veículos (`removeVehicle`);
- Criar o `customHook` `useVehicles` que lida com os retornos dos serviços citados anteriormente atualizando o estado local de maneira correta, ou enviando um alerta para o usuário caso necessário;
- Adaptar `VehiclesList` para utilizar o novo `useVehicles`.

