### PR TITLE
[RF010-FE-2] Conexão tela de cadastro/alteração de veículos com backend

### DIFF
--- a/src/screens/Vehicles/VehicleRegistry/brandsParser.js
+++ b/src/screens/Vehicles/VehicleRegistry/brandsParser.js
@@ -1,7 +1,7 @@
 const brandsParser = (brands) =>
   brands.map((brand) => ({
     label: brand.nome,
-    value: { id: brand.id, nome: brand.nome }
+    value: { id: brand.id, name: brand.nome }
   }));
 
 export default brandsParser;

--- a/src/screens/Vehicles/VehicleRegistry/hooks/tests/useVehicleRegistry.test.js
+++ b/src/screens/Vehicles/VehicleRegistry/hooks/tests/useVehicleRegistry.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import useVehicleRegistry from '../useVehicleRegistry';
+import { registerVehicle } from '../../../services';
+import { SnackBarContext } from '../../../../../contexts/snackbar';
+import { AuthenticationContext } from '../../../../../contexts/authentication';
+
+jest.mock('../../../services');
+
+const mockHistoryPush = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: mockHistoryPush,
+  }),
+}));
+
+describe('useVehicleRegistry', () => {
+  const mockedSnackbarValue = { addAlert: jest.fn() };
+  const mockedAuthValue = { userJWT: 'fakeuserjwt' };
+  const wrapper = ({ children }) => (
+    <SnackBarContext.Provider value={mockedSnackbarValue}>
+      <AuthenticationContext.Provider value={mockedAuthValue}>
+        {children}
+      </AuthenticationContext.Provider>
+    </SnackBarContext.Provider>
+  );
+
+  describe('registerVehicle handling', () => {
+    it('should redirect user to / and call addAlert after the vehicle is registered correctly',
+      async () => {
+        registerVehicle.mockImplementationOnce(() => Promise.resolve());
+
+        const { result, waitForNextUpdate } = renderHook(() => useVehicleRegistry(), { wrapper });
+        act(() => {
+          result.current.register();
+        });
+        await waitForNextUpdate();
+        expect(mockedSnackbarValue.addAlert).toHaveBeenCalledWith({
+          content: 'Veículo cadastrado corretamente!',
+          customSeverity: 'success',
+        });
+        expect(mockHistoryPush).toHaveBeenCalledWith('/');
+      }
+    );
+    
+    it('should set isLoading to true at the start of the registerVehicle and to false after that',
+      async () => {
+        registerVehicle.mockImplementationOnce(() => Promise.resolve());
+  
+        const { result, waitForNextUpdate } = renderHook(() => useVehicleRegistry(), { wrapper });
+        act(() => {
+          result.current.register();
+        });
+        expect(result.current.isLoading).toBeTruthy();
+        await waitForNextUpdate();
+        expect(result.current.isLoading).toBeFalsy();
+      }
+    );
+  
+    it('should call the addAlert function when the registerVehicle returns an error', async () => {
+      const mockedServiceReturn = { error: 'error' };
+      registerVehicle.mockImplementationOnce(() => Promise.reject(mockedServiceReturn));
+  
+      const { result, waitForNextUpdate } = renderHook(() => useVehicleRegistry(), { wrapper });
+      act(() => {
+        result.current.register();
+      });
+      await waitForNextUpdate();
+      expect(mockedSnackbarValue.addAlert).toHaveBeenCalledWith({
+        content: 'Erro inesperado ao registrar veículo!',
+        customSeverity: 'error',
+      });
+    });
+  });
+});

--- a/src/screens/Vehicles/VehicleRegistry/hooks/tests/useVehicleUpdate.test.js
+++ b/src/screens/Vehicles/VehicleRegistry/hooks/tests/useVehicleUpdate.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import useVehicleUpdate from '../useVehicleUpdate';
+import { updateVehicle } from '../../../services';
+import { SnackBarContext } from '../../../../../contexts/snackbar';
+import { AuthenticationContext } from '../../../../../contexts/authentication';
+
+jest.mock('../../../services');
+
+const mockHistoryPush = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: mockHistoryPush,
+  }),
+}));
+
+describe('useVehicleUpdate', () => {
+  const mockedSnackbarValue = { addAlert: jest.fn() };
+  const mockedAuthValue = { userJWT: 'fakeuserjwt' };
+  const wrapper = ({ children }) => (
+    <SnackBarContext.Provider value={mockedSnackbarValue}>
+      <AuthenticationContext.Provider value={mockedAuthValue}>
+        {children}
+      </AuthenticationContext.Provider>
+    </SnackBarContext.Provider>
+  );
+
+  describe('updateVehicle handling', () => {
+    it('should redirect user to / and call addAlert after the vehicle is updated correctly',
+      async () => {
+        updateVehicle.mockImplementationOnce(() => Promise.resolve());
+
+        const { result, waitForNextUpdate } = renderHook(() => useVehicleUpdate(), { wrapper });
+        act(() => {
+          result.current.update();
+        });
+        await waitForNextUpdate();
+        expect(mockedSnackbarValue.addAlert).toHaveBeenCalledWith({
+          content: 'Veículo atualizado corretamente!',
+          customSeverity: 'success',
+        });
+        expect(mockHistoryPush).toHaveBeenCalledWith('/');
+      }
+    );
+    
+    it('should set isLoading to true at the start of the updateVehicle and to false after that',
+      async () => {
+        updateVehicle.mockImplementationOnce(() => Promise.resolve());
+  
+        const { result, waitForNextUpdate } = renderHook(() => useVehicleUpdate(), { wrapper });
+        act(() => {
+          result.current.update();
+        });
+        expect(result.current.isLoading).toBeTruthy();
+        await waitForNextUpdate();
+        expect(result.current.isLoading).toBeFalsy();
+      }
+    );
+  
+    it('should call the addAlert function when the updateVehicle returns an error', async () => {
+      const mockedServiceReturn = { error: 'error' };
+      updateVehicle.mockImplementationOnce(() => Promise.reject(mockedServiceReturn));
+  
+      const { result, waitForNextUpdate } = renderHook(() => useVehicleUpdate(), { wrapper });
+      act(() => {
+        result.current.update();
+      });
+      await waitForNextUpdate();
+      expect(mockedSnackbarValue.addAlert).toHaveBeenCalledWith({
+        content: 'Erro inesperado ao atualizar veículo!',
+        customSeverity: 'error',
+      });
+    });
+  });
+});

--- a/src/screens/Vehicles/VehicleRegistry/hooks/useVehicleRegistry.js
+++ b/src/screens/Vehicles/VehicleRegistry/hooks/useVehicleRegistry.js
@@ -1,8 +1,33 @@
-const useVehicleRegistry = () => {
-  const registerVehicle = () => true;
-  const updateVehicle = () => true;
+import { useState, useContext } from 'react';
+import { useHistory } from 'react-router-dom';
 
-  return { registerVehicle, updateVehicle };
+import { SnackBarContext } from '../../../../contexts/snackbar';
+import { AuthenticationContext } from '../../../../contexts/authentication';
+
+import { registerVehicle } from '../../services';
+
+const useVehicleRegistry = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const { addAlert } = useContext(SnackBarContext);
+  const { userJWT } = useContext(AuthenticationContext);
+  const history = useHistory();
+
+  const register = (brand, model, year, value) => {
+    setIsLoading(true);
+    registerVehicle(userJWT, brand, model, year, value)
+      .then(() => {
+        addAlert({ content: 'Veículo cadastrado corretamente!', customSeverity: 'success' });
+        history.push('/');
+      })
+      .catch(() => {
+        addAlert({ content: 'Erro inesperado ao registrar veículo!', customSeverity: 'error' });
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  return { register, isLoading };
 };
 
 export default useVehicleRegistry;

--- a/src/screens/Vehicles/VehicleRegistry/hooks/useVehicleUpdate.js
+++ b/src/screens/Vehicles/VehicleRegistry/hooks/useVehicleUpdate.js
@@ -1,0 +1,33 @@
+import { useState, useContext } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { SnackBarContext } from '../../../../contexts/snackbar';
+import { AuthenticationContext } from '../../../../contexts/authentication';
+
+import { updateVehicle } from '../../services';
+
+const useVehicleUpdate = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const { addAlert } = useContext(SnackBarContext);
+  const { userJWT } = useContext(AuthenticationContext);
+  const history = useHistory();
+
+  const update = (vehicleId, brand, model, year, value) => {
+    setIsLoading(true);
+    updateVehicle(userJWT, vehicleId, brand, model, year, value)
+      .then(() => {
+        addAlert({ content: 'Veículo atualizado corretamente!', customSeverity: 'success' });
+        history.push('/');
+      })
+      .catch(() => {
+        addAlert({ content: 'Erro inesperado ao atualizar veículo!', customSeverity: 'error' });
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  return { update, isLoading };
+};
+
+export default useVehicleUpdate;

--- a/src/screens/Vehicles/VehicleRegistry/index.js
+++ b/src/screens/Vehicles/VehicleRegistry/index.js
@@ -28,12 +28,14 @@ const VehicleRegistry = () => {
   const { pathname } = useLocation();
   const { vehicleId } = useParams();
   const { register: registerVehicle, isLoading: isRegisterLoading } = useVehicleRegistry();
-  const { update: updateVehicle } = useVehicleUpdate();
+  const { update: updateVehicle, isLoading: isUpdateLoading } = useVehicleUpdate();
   const [brand, setBrand] = React.useState({});
   const [model, setModel] = React.useState('');
   const [year, setYear] = React.useState();
   const [value, setValue] = React.useState();
   const [errors, validateFields, isFormValid] = useErrors(validations);
+  const shouldDisableRegistryButton = !isFormValid() || isRegisterLoading;
+  const shouldDisableUpdateButton = !isFormValid() || isUpdateLoading;
 
   const isRegistryMode = pathname.includes('/cadastro-veiculo');
   const isUpdateMode = pathname.includes('/alteracao-veiculo');
@@ -132,14 +134,14 @@ const VehicleRegistry = () => {
             </FormControl>
           </Grid>
           <Grid item container justify="space-between" xs={8}>
-            <FormButton to="/usuarios" isLink>
+            <FormButton to="/" isLink>
               Cancelar
             </FormButton>
             {isRegistryMode &&
               <FormButton
                 color="primary"
                 type="submit"
-                disabled={!isFormValid()}
+                disabled={shouldDisableRegistryButton}
               >
                 {isRegisterLoading ? <CircularProgress /> : 'Cadastrar'}
               </FormButton>
@@ -148,9 +150,9 @@ const VehicleRegistry = () => {
               <FormButton
                 color="primary"
                 type="submit"
-                disabled={!isFormValid()}
+                disabled={shouldDisableUpdateButton}
               >
-                Alterar
+                {isUpdateLoading ? <CircularProgress /> : 'Alterar'}
               </FormButton>
             }
           </Grid>

--- a/src/screens/Vehicles/VehicleRegistry/index.js
+++ b/src/screens/Vehicles/VehicleRegistry/index.js
@@ -11,7 +11,8 @@ import {
   FormHelperText,
   MenuItem,
   Box,
-  Typography
+  Typography,
+  CircularProgress,
 } from '@material-ui/core';
 
 import FormButton from '../../../components/FormButton';
@@ -19,13 +20,15 @@ import useErrors from '../../../hooks/useErrors';
 
 import useBrands from './hooks/useBrands';
 import useVehicleRegistry from './hooks/useVehicleRegistry';
+import useVehicleUpdate from './hooks/useVehicleUpdate';
 import validations from './validations';
 
 const VehicleRegistry = () => {
   const { brands } = useBrands();
   const { pathname } = useLocation();
   const { vehicleId } = useParams();
-  const { registerVehicle, updateVehicle } = useVehicleRegistry();
+  const { register: registerVehicle, isLoading: isRegisterLoading } = useVehicleRegistry();
+  const { update: updateVehicle } = useVehicleUpdate();
   const [brand, setBrand] = React.useState({});
   const [model, setModel] = React.useState('');
   const [year, setYear] = React.useState();
@@ -138,7 +141,7 @@ const VehicleRegistry = () => {
                 type="submit"
                 disabled={!isFormValid()}
               >
-                Cadastrar
+                {isRegisterLoading ? <CircularProgress /> : 'Cadastrar'}
               </FormButton>
             }
             {isUpdateMode &&

--- a/src/screens/Vehicles/VehicleRegistry/tests/brandsParser.test.js
+++ b/src/screens/Vehicles/VehicleRegistry/tests/brandsParser.test.js
@@ -10,11 +10,11 @@ describe('brandsParser', () => {
     const expectedReturn = [
       {
         label: 'FORD',
-        value: { id: 34, nome: 'FORD' },
+        value: { id: 34, name: 'FORD' },
       },
       {
         label: 'FIAT',
-        value: { id: 32, nome: 'FIAT' },
+        value: { id: 32, name: 'FIAT' },
       },
     ];
     expect(brandsParser(mockedBrandsServiceGetAllReturn)).toEqual(expectedReturn);

--- a/src/screens/Vehicles/VehicleRegistry/tests/index.test.js
+++ b/src/screens/Vehicles/VehicleRegistry/tests/index.test.js
@@ -101,6 +101,19 @@ describe('Create/update vehicle form', () => {
       );
       expect(getByRole('progressbar')).toBeInTheDocument();
     });
+
+    it('should render the loading component when the update is loading (update mode)', () => {
+      cleanup();
+      mockedLocationPathname = '/alteracao-veiculo';
+      useVehicleRegistry.mockReturnValue({ register: jest.fn() });
+      useVehicleUpdate.mockReturnValue({ update: jest.fn(), isLoading: true });
+      const { getByRole } = render(
+        <MemoryRouter>
+          <VehicleRegistry />
+        </MemoryRouter>,
+      );
+      expect(getByRole('progressbar')).toBeInTheDocument();
+    });
   });
 
   describe('form functioning', () => {

--- a/src/screens/Vehicles/VehicleRegistry/tests/index.test.js
+++ b/src/screens/Vehicles/VehicleRegistry/tests/index.test.js
@@ -6,11 +6,13 @@ import VehicleRegistry from '..';
 
 import useBrands from '../hooks/useBrands';
 import useVehicleRegistry from '../hooks/useVehicleRegistry';
+import useVehicleUpdate from '../hooks/useVehicleUpdate';
 import brandsParser from '../brandsParser';
 import mockedBrands from '../hooks/tests/mockedBrands';
 
 jest.mock('../hooks/useBrands');
 jest.mock('../hooks/useVehicleRegistry');
+jest.mock('../hooks/useVehicleUpdate');
 
 const mockedVehicleId = 123;
 let mockedLocationPathname = '/cadastro-veiculo';
@@ -33,7 +35,8 @@ describe('Create/update vehicle form', () => {
 
   beforeEach(() => {
     useBrands.mockReturnValue({ brands: brandsParser(mockedBrands) });
-    useVehicleRegistry.mockReturnValue({ registerVehicle: jest.fn(), updateVehicle: jest.fn() });
+    useVehicleRegistry.mockReturnValue({ register: jest.fn() });
+    useVehicleUpdate.mockReturnValue({ update: jest.fn() });
     render(
       <MemoryRouter>
         <VehicleRegistry />
@@ -85,6 +88,19 @@ describe('Create/update vehicle form', () => {
       const renderedOptions = screen.getAllByRole('option');
       expect(renderedOptions).toHaveLength(mockedBrands.length);
     });
+
+    it('should render the loading component when the register is loading (registry mode)', () => {
+      cleanup();
+      mockedLocationPathname = '/cadastro-veiculo';
+      useVehicleRegistry.mockReturnValue({ register: jest.fn(), isLoading: true });
+      useVehicleUpdate.mockReturnValue({ update: jest.fn() });
+      const { getByRole } = render(
+        <MemoryRouter>
+          <VehicleRegistry />
+        </MemoryRouter>,
+      );
+      expect(getByRole('progressbar')).toBeInTheDocument();
+    });
   });
 
   describe('form functioning', () => {
@@ -93,10 +109,8 @@ describe('Create/update vehicle form', () => {
       const mockedUpdateService = jest.fn();
       mockedLocationPathname = `/alteracao-veiculo/${mockedVehicleId}`;
       useBrands.mockReturnValue({ brands: brandsParser(mockedBrands) });
-      useVehicleRegistry.mockReturnValue({
-        registerVehicle: jest.fn(),
-        updateVehicle: mockedUpdateService,
-      });
+      useVehicleRegistry.mockReturnValue({ register: jest.fn() });
+      useVehicleUpdate.mockReturnValue({ update: mockedUpdateService });
       const { getByRole, getAllByRole } = render(
         <MemoryRouter>
           <VehicleRegistry />
@@ -125,7 +139,7 @@ describe('Create/update vehicle form', () => {
 
       const expectedForm = {
         vehicleId: mockedVehicleId,
-        brand: { id: 32, nome: 'FIAT' },
+        brand: { id: 32, name: 'FIAT' },
         model: 'Fake car mock',
         year: '2000',
         value: '100000',
@@ -147,10 +161,8 @@ describe('Create/update vehicle form', () => {
       const mockedRegisterVehicle = jest.fn();
       mockedLocationPathname = '/cadastro-veiculo';
       useBrands.mockReturnValue({ brands: brandsParser(mockedBrands) });
-      useVehicleRegistry.mockReturnValue({
-        registerVehicle: mockedRegisterVehicle,
-        updateVehicle: jest.fn(),
-      });
+      useVehicleRegistry.mockReturnValue({ register: mockedRegisterVehicle });
+      useVehicleUpdate.mockReturnValue({ update: jest.fn() });
       const { getByRole, getAllByRole } = render(
         <MemoryRouter>
           <VehicleRegistry />
@@ -178,7 +190,7 @@ describe('Create/update vehicle form', () => {
       fireEvent.focusOut(valueInput);
 
       const expectedForm = {
-        brand: { id: 32, nome: 'FIAT' },
+        brand: { id: 32, name: 'FIAT' },
         model: 'Fake car mock',
         year: '2000',
         value: '100000',

--- a/src/screens/Vehicles/services/index.js
+++ b/src/screens/Vehicles/services/index.js
@@ -12,3 +12,25 @@ export const removeVehicle = async (vehicleId, userJWT) => {
 
   return fetch(`${API_URL}/veiculo/${vehicleId}`, requestOptions).then(fetchResponseHandler);
 };
+
+export const registerVehicle = (userJWT, brand, model, year, value) => {
+  const requestBody = {
+    marca: {
+      id: brand.id,
+      nome: brand.name,
+    },
+    modelo: model,
+    ano: year,
+    preco: value,
+  };
+  const requestOptions = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...buildAuthHeader(userJWT),
+    },
+    body: JSON.stringify(requestBody),
+  };
+
+  return fetch(`${API_URL}/veiculo`, requestOptions).then(fetchResponseHandler);
+};

--- a/src/screens/Vehicles/services/index.js
+++ b/src/screens/Vehicles/services/index.js
@@ -2,6 +2,17 @@ import { API_URL } from "../../../services/constants";
 import fetchResponseHandler from "../../../services/fetchResponseHandler";
 import buildAuthHeader from '../../../services/buildAuthHeader'
 
+const buildRequestBody = (brand, model, year, value) => ({
+  marca: {
+    id: brand.id,
+    nome: brand.name,
+  },
+  modelo: model,
+  ano: year,
+  preco: value,
+  isVendido: false,
+});
+
 export const getAllVehicles = async () => fetch(`${API_URL}/veiculo`).then(fetchResponseHandler);
 
 export const removeVehicle = async (vehicleId, userJWT) => {
@@ -14,23 +25,27 @@ export const removeVehicle = async (vehicleId, userJWT) => {
 };
 
 export const registerVehicle = (userJWT, brand, model, year, value) => {
-  const requestBody = {
-    marca: {
-      id: brand.id,
-      nome: brand.name,
-    },
-    modelo: model,
-    ano: year,
-    preco: value,
-  };
   const requestOptions = {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       ...buildAuthHeader(userJWT),
     },
-    body: JSON.stringify(requestBody),
+    body: JSON.stringify(buildRequestBody(brand, model, year, value)),
   };
 
   return fetch(`${API_URL}/veiculo`, requestOptions).then(fetchResponseHandler);
+};
+
+export const updateVehicle = (userJWT, vehicleId, brand, model, year, value) => {
+  const requestOptions = {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      ...buildAuthHeader(userJWT),
+    },
+    body: JSON.stringify(buildRequestBody(brand, model, year, value)),
+  };
+
+  return fetch(`${API_URL}/veiculo/${vehicleId}`, requestOptions).then(fetchResponseHandler);
 };

--- a/src/screens/Vehicles/services/tests/index.test.js
+++ b/src/screens/Vehicles/services/tests/index.test.js
@@ -1,4 +1,4 @@
-import { getAllVehicles, removeVehicle, registerVehicle } from '..';
+import { getAllVehicles, removeVehicle, registerVehicle, updateVehicle } from '..';
 
 import { API_URL } from '../../../../services/constants';
 import buildAuthHeader from '../../../../services/buildAuthHeader';
@@ -53,11 +53,46 @@ describe('Vehicles services', () => {
         modelo: mockedModel,
         ano: mockedYear,
         preco: mockedValue,
+        isVendido: false,
       };
       expect(window.fetch).toHaveBeenCalledWith(
         `${API_URL}/veiculo`,
         {
           method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...buildAuthHeader(mockedJWT),
+          },
+          body: JSON.stringify(expectedBody),
+        },
+      );
+    });
+  });
+
+  describe('updateVehicle', () => {
+    it('should call the fetch function with the correct url and options', () => {
+      const mockedJWT = 'fakeuserjwt';
+      const mockedVehicleId = 99;
+      const mockedBrand = { id: 1, name: 'Fake Brand' };
+      const mockedModel = 'Fake vehicle model';
+      const mockedYear = 1999;
+      const mockedValue = 20000;
+      updateVehicle(mockedJWT, mockedVehicleId, mockedBrand, mockedModel, mockedYear, mockedValue);
+
+      const expectedBody = {
+        marca: {
+          id: mockedBrand.id,
+          nome: mockedBrand.name,
+        },
+        modelo: mockedModel,
+        ano: mockedYear,
+        preco: mockedValue,
+        isVendido: false,
+      };
+      expect(window.fetch).toHaveBeenCalledWith(
+        `${API_URL}/veiculo/${mockedVehicleId}`,
+        {
+          method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
             ...buildAuthHeader(mockedJWT),

--- a/src/screens/Vehicles/services/tests/index.test.js
+++ b/src/screens/Vehicles/services/tests/index.test.js
@@ -1,4 +1,4 @@
-import { getAllVehicles, removeVehicle } from '..';
+import { getAllVehicles, removeVehicle, registerVehicle } from '..';
 
 import { API_URL } from '../../../../services/constants';
 import buildAuthHeader from '../../../../services/buildAuthHeader';
@@ -21,7 +21,7 @@ describe('Vehicles services', () => {
   });
 
   describe('removeVehicle', () => {
-    it('should call the fetch function with the correct url', () => {
+    it('should call the fetch function with the correct url and options', () => {
       const mockedVehicleId = 123;
       const mockedJWT = 'fakeuserjwt';
       removeVehicle(mockedVehicleId, mockedJWT);
@@ -31,6 +31,38 @@ describe('Vehicles services', () => {
         {
           method: 'DELETE',
           headers: buildAuthHeader(mockedJWT),
+        },
+      );
+    });
+  });
+
+  describe('registerVehicle', () => {
+    it('should call the fetch function with the correct url and options', () => {
+      const mockedJWT = 'fakeuserjwt';
+      const mockedBrand = { id: 1, name: 'Fake Brand' };
+      const mockedModel = 'Fake vehicle model';
+      const mockedYear = 1999;
+      const mockedValue = 20000;
+      registerVehicle(mockedJWT, mockedBrand, mockedModel, mockedYear, mockedValue);
+
+      const expectedBody = {
+        marca: {
+          id: mockedBrand.id,
+          nome: mockedBrand.name,
+        },
+        modelo: mockedModel,
+        ano: mockedYear,
+        preco: mockedValue,
+      };
+      expect(window.fetch).toHaveBeenCalledWith(
+        `${API_URL}/veiculo`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...buildAuthHeader(mockedJWT),
+          },
+          body: JSON.stringify(expectedBody),
         },
       );
     });


### PR DESCRIPTION
## Descrição
Esse PR cria funcionalidades necessárias para que a tela de cadastro/alteração de veículos envie informações para o backend da aplicação corretamente. Para isso foi necessário:

- Criar serviços que enviam forms de cadastro e alteração de veículos para o backend (`registerVehicle` / `updateVehicle`);
- Criar custom hooks `useVehicleRegistry` e `useVehicleUpdate` para lidar com os retornos dos serviços criados, redirecionando o usuário e enviando alertas para o usuário corretamente;
- Adaptar `VehicleRegistry` para utilizar os novos custom hooks.