### PR TITLE
[RF012-FE] Tela de dashboard

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -8,6 +8,7 @@ import VehiclesList from '../screens/Vehicles/VehiclesList';
 import VehicleRegistry from '../screens/Vehicles/VehicleRegistry';
 import UserRegistration from '../screens/Users/UserRegistration';
 import UsersList from '../screens/Users/UsersList';
+import Dashboard from '../screens/Dashboard';
 
 import AuthenticationRoute from './AuthenticationRoute';
 
@@ -35,7 +36,7 @@ const Routes = () => (
       <UsersList />
     </AuthenticationRoute>
     <AuthenticationRoute exact path="/dashboard" isPrivate>
-      <div>dashboard</div>
+      <Dashboard />
     </AuthenticationRoute>
     <AuthenticationRoute exact path="/login">
       <Login />

--- a/src/screens/Dashboard/hooks/dashboardParser.js
+++ b/src/screens/Dashboard/hooks/dashboardParser.js
@@ -1,0 +1,9 @@
+const dashboardParser = (dashboard) =>
+  dashboard.map((dashboardBrandInfo) => ({
+    brand: dashboardBrandInfo.nomeMarca,
+    vehicleNumber: dashboardBrandInfo.qtdeVeiculos || 0,
+    totalValue: dashboardBrandInfo.valorTotalVeiculos || 0,
+  }));
+
+export default dashboardParser;
+

--- a/src/screens/Dashboard/hooks/tests/dashboardParser.test.js
+++ b/src/screens/Dashboard/hooks/tests/dashboardParser.test.js
@@ -1,0 +1,45 @@
+import dashboardParser from '../dashboardParser';
+
+const mockedDashboardServiceGetReturn = [
+  {
+    nomeMarca: 'FORD',
+    qtdeVeiculos: 6,
+    valorTotalVeiculos: 80000,
+  },
+  {
+    nomeMarca: 'FIAT',
+    qtdeVeiculos: 3,
+    valorTotalVeiculos: 55000,
+  },
+];
+
+describe('dashboardParser', () => {
+  it('should parse the dashboard get service return correctly', () => {
+    const expectedReturn = [
+      {
+        brand: 'FORD',
+        vehicleNumber: 6,
+        totalValue: 80000,
+      },
+      {
+        brand: 'FIAT',
+        vehicleNumber: 3,
+        totalValue: 55000,
+      },
+    ];
+    expect(dashboardParser(mockedDashboardServiceGetReturn)).toEqual(expectedReturn);
+  });
+
+  it('should set vehicleNumber and totalValue to zero if the service doesnt return them', () => {
+    const mockedEmptyDashboardServiceGetReturn = [{ nomeMarca: 'FORD' }];
+
+    const expectedReturn = [
+      {
+        brand: 'FORD',
+        vehicleNumber: 0,
+        totalValue: 0,
+      },
+    ];
+    expect(dashboardParser(mockedEmptyDashboardServiceGetReturn)).toEqual(expectedReturn);
+  });
+});

--- a/src/screens/Dashboard/hooks/tests/useDashboard.test.js
+++ b/src/screens/Dashboard/hooks/tests/useDashboard.test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import useDashboard from '../useDashboard';
+import { getDashboard } from '../../services';
+import { SnackBarContext } from '../../../../contexts/snackbar';
+import { AuthenticationContext } from '../../../../contexts/authentication';
+
+import dashboardParser from '../dashboardParser';
+
+jest.mock('../../services');
+
+const mockHistoryPush = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useHistory: () => ({
+    push: mockHistoryPush,
+  }),
+}));
+
+const mockedDashboard = [
+  {
+    nomeMarca: 'Fake brand 1',
+    qtdeVeiculos: 6,
+    valorTotalVeiculos: 80000,
+  },
+  {
+    nomeMarca: 'Fake brand 2',
+    qtdeVeiculos: 3,
+    valorTotalVeiculos: 55000,
+  }
+];
+
+describe('useDashboard', () => {
+  const mockedSnackbarValue = { addAlert: jest.fn() };
+  const mockedAuthValue = { userJWT: 'fakeuserjwt' };
+  const wrapper = ({ children }) => (
+    <SnackBarContext.Provider value={mockedSnackbarValue}>
+      <AuthenticationContext.Provider value={mockedAuthValue}>
+        {children}
+      </AuthenticationContext.Provider>
+    </SnackBarContext.Provider>
+  );
+
+  describe('getDashboard handling', () => {
+    it('should handle the getDashboard correctly after the hook first useEffect', async () => {
+      getDashboard.mockImplementationOnce(() => Promise.resolve(mockedDashboard));
+  
+      const { result, waitForNextUpdate } = renderHook(() => useDashboard(), { wrapper });
+      await waitForNextUpdate();
+      expect(result.current.dashboardInfo).toEqual(dashboardParser(mockedDashboard));
+    });
+    
+    it('should update isLoading to true at the start of getDashboard and to false after that',
+      async () => {
+        getDashboard.mockImplementationOnce(() => Promise.resolve(mockedDashboard));
+  
+        const { result, waitForNextUpdate } = renderHook(() => useDashboard(), { wrapper });
+        expect(result.current.isLoading).toBeTruthy();
+        await waitForNextUpdate();
+        expect(result.current.isLoading).toBeFalsy();
+      }
+    );
+  
+    it('should call the addAlert function when the getDashboard returns an error', async () => {
+      const mockedServiceReturn = { error: 'error' };
+      getDashboard.mockImplementationOnce(() => Promise.reject(mockedServiceReturn));
+  
+      const { waitForNextUpdate } = renderHook(() => useDashboard(), { wrapper });
+      await waitForNextUpdate();
+      expect(mockedSnackbarValue.addAlert).toHaveBeenCalledWith({
+        content: 'Erro inesperado ao carregar informações do dashboard!',
+        customSeverity: 'error',
+      });
+      expect(mockHistoryPush).toHaveBeenCalledWith('/');
+    });
+  });
+});

--- a/src/screens/Dashboard/hooks/useDashboard.js
+++ b/src/screens/Dashboard/hooks/useDashboard.js
@@ -1,0 +1,42 @@
+import { useState, useEffect, useContext } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import { SnackBarContext } from '../../../contexts/snackbar';
+import { AuthenticationContext } from '../../../contexts/authentication';
+
+import { getDashboard } from '../services';
+import dashboardParser from './dashboardParser';
+
+const useDashboard = () => {
+  const [dashboardInfo, setDashboardInfo] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const { addAlert } = useContext(SnackBarContext);
+  const { userJWT } = useContext(AuthenticationContext);
+  const history = useHistory();
+
+  const loadDashboard = () => {
+    getDashboard(userJWT)
+      .then((data) => {
+        setDashboardInfo(dashboardParser(data));
+      })
+      .catch(() => {
+        addAlert({
+          content: 'Erro inesperado ao carregar informações do dashboard!',
+          customSeverity: 'error',
+        });
+        history.push('/');
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  };
+
+  useEffect(() => {
+    setIsLoading(true);
+    loadDashboard();
+  }, []);
+
+  return { dashboardInfo, isLoading };
+};
+
+export default useDashboard;

--- a/src/screens/Dashboard/index.js
+++ b/src/screens/Dashboard/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { Typography, Card, CardContent, Grid, CircularProgress } from '@material-ui/core';
+
+import useDashboard from './hooks/useDashboard';
+
+const Dashboard = () => {
+  const { dashboardInfo, isLoading } = useDashboard();
+
+  return (
+    <>
+      <Typography variant="h4" component="h2" gutterBottom>
+        Dashboard
+      </Typography>
+      {isLoading && <CircularProgress />}
+      <Grid container spacing={6}>
+        {
+          dashboardInfo.map((brandInfo) => (
+            <Grid item xs={6} data-testid="dashboard-card" key={brandInfo.brand}>
+              <Card>
+                <CardContent>
+                  <Typography variant="subtitle2" component="p">Marca:</Typography>
+                  <Typography variant="h5" component="p" gutterBottom>{brandInfo.brand}</Typography>
+                  <Typography variant="subtitle2" component="p">Qtd de veículos:</Typography>
+                  <Typography variant="h5" component="p" gutterBottom>
+                    {brandInfo.vehicleNumber}
+                  </Typography>
+                  <Typography variant="subtitle2" component="p">Valor total:</Typography>
+                  <Typography variant="h5" component="p">R$ {brandInfo.totalValue}</Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          ))
+        }
+      </Grid>
+    </>
+  );
+};
+
+export default Dashboard

--- a/src/screens/Dashboard/services/index.js
+++ b/src/screens/Dashboard/services/index.js
@@ -1,0 +1,12 @@
+import { API_URL } from '../../../services/constants';
+import buildAuthHeader from '../../../services/buildAuthHeader';
+import fetchResponseHandler from '../../../services/fetchResponseHandler';
+
+export const getDashboard = (userJWT) => {
+  const requestOptions = {
+    method: 'GET',
+    headers: buildAuthHeader(userJWT),
+  };
+
+  return fetch(`${API_URL}/marcas/dashboard`, requestOptions).then(fetchResponseHandler);
+};

--- a/src/screens/Dashboard/services/tests/index.test.js
+++ b/src/screens/Dashboard/services/tests/index.test.js
@@ -1,0 +1,24 @@
+import { getDashboard } from '..';
+
+import { API_URL } from '../../../../services/constants';
+import buildAuthHeader from '../../../../services/buildAuthHeader';
+
+beforeAll(() => jest.spyOn(window, 'fetch'));
+
+describe('Dashboard services', () => {
+  beforeEach(() => {
+    window.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+  });
+  it('should call the fetch function with the correct url and options', async () => {
+    const mockedUserJWT = 'fakeuserjwt';
+    getDashboard(mockedUserJWT);
+
+    expect(window.fetch).toHaveBeenCalledWith(`${API_URL}/marcas/dashboard`, {
+      method: 'GET',
+      headers: buildAuthHeader(mockedUserJWT),
+    });
+  });
+});

--- a/src/screens/Dashboard/tests/index.test.js
+++ b/src/screens/Dashboard/tests/index.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import Dashboard from '..';
+import useDashboard from '../hooks/useDashboard';
+
+jest.mock('../hooks/useDashboard');
+
+const mockedDashboardInfo = [
+  {
+    brand: 'Fake brand 1',
+    vehicleNumber: 6,
+    totalValue: 80000,
+  },
+  {
+    brand: 'Fake brand 2',
+    vehicleNumber: 3,
+    totalValue: 55000,
+  },
+  {
+    brand: 'Fake brand 3',
+    vehicleNumber: 8,
+    totalValue: 550000,
+  },
+  {
+    brand: 'Fake brand 4',
+    vehicleNumber: 1,
+    totalValue: 5001,
+  },
+];
+
+describe('<Dashboard />', () => {
+  describe('rendering', () => {
+    it('should render the VehiclesList component correctly', () => {
+      useDashboard.mockReturnValue({
+        dashboardInfo: mockedDashboardInfo,
+        isLoading: false,
+      });
+      render(<Dashboard />);
+
+      expect(screen.getByText('Dashboard')).toBeInTheDocument();
+      expect(screen.getAllByTestId('dashboard-card')).toHaveLength(4);
+    });
+
+    it('should render circularProgress component when the dashboardInfo is loading', () => {
+      useDashboard.mockReturnValue({
+        dashboardInfo: mockedDashboardInfo,
+        isLoading: true,
+      });
+      render(<Dashboard />);
+
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Descrição
Esse PR adiciona a tela de dashboard na aplicação, é possível acessar a tela pela rota `/dashboard`. A tela possui as seguintes funcionalidades:

- Cria serviço que bate no endpoint do backend para pegar informações que serão dispostas;
- Cria custom hook `useDashboard` para lidar com o retorno do serviço criado;
- Cria tela para dispor informações de dashboard para usuário.

### Anexo
![print screen da tela de dashboard](https://user-images.githubusercontent.com/17559048/124985125-70b5e700-e010-11eb-8ca9-c853184625cd.png)


